### PR TITLE
fix #19: thread-safe Start() + fix EventSource leak on stop→start

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -11,10 +11,9 @@
 - **M2 code change behavior** `[large] [mid]`: The app references Macaulay2 code that can change externally (e.g. switching branches on ext-shifting). It is unclear how the app should respond to such changes.
 
 - **Macaulay2 package lifecycle** `[large] [mid]`: The ext-shifting M2 code is not yet published as a proper Macaulay2 package; the Docker image currently bundles source rather than installing a published package.
+  - **Docker installPackage migration** `[small] [mid]`: Once the ext-shifting M2 code is published as a Macaulay2 package, the Dockerfile should install it via `installPackage` rather than bundling source. Depends on Macaulay2 package publication.
 
 - **Automorphism-aware split filtering** `[large] [mid]`: The analysis does not account for triangulation symmetry when selecting split candidates. Vertices in the same automorphism orbit are redundant to split at, and vertices with non-trivial symmetries may also be skippable — the split exemption mechanism is a likely vehicle for both filters. For each split that is filtered out, it should be documented which non-filtered split in the same orbit covers it. Sized large because automorphism groups must be determined offline per triangulation and encoded as hard-coded exemptions, spanning potentially many triangulations.
-  - **Macaulay2 package publication** `[large] [mid]`: The ext-shifting M2 code is bundled as a git submodule; it has not been published as a proper Macaulay2 package. Noted as a future goal in the PRD with architectural implications for how the Docker image bundles M2 code.
-  - **Docker installPackage migration** `[small] [mid]`: Once the ext-shifting M2 code is published as a Macaulay2 package, the Dockerfile should install it via `installPackage` rather than bundling source. Depends on Macaulay2 package publication.
 
 - **Run name conflicts on restart** `[medium] [mid]`: When starting an analysis with a run name that already has on-disk state from a previous run, the behavior is undefined — output directories may conflict, iteration counters may be stale, and errors may occur mid-run. Spans job lifecycle management on the C# side and may require UI affordances for cleaning up or reusing old runs.
 
@@ -32,3 +31,5 @@
   - **Output visualisation** `[medium] [low]`: The shifted complex is displayed as a list; there is no graphical rendering. Noted as future work in the PRD.
 
 - **Show absolute path in iterative analysis** `[small] [low]`: When running iterative analysis, the file path shown in the log is relative. It is unclear what the full path resolves to on the host.
+
+- **Remove batch-file iteration terminology from user-facing outputs** `[small] [low]`: The old batch-file iteration model introduced terms like `currentIteration` that no longer apply to the queue-based analysis. Any remnants of this terminology in the API response body, SSE events, UI labels, README, and ubiquitous language files should be identified and removed to avoid confusion. (Issue #8 was closed as deprecated; this item tracks the cleanup.)

--- a/src/ExtShiftingApp.Tests/Analysis/AnalysisJobManagerTests.cs
+++ b/src/ExtShiftingApp.Tests/Analysis/AnalysisJobManagerTests.cs
@@ -434,6 +434,67 @@ public class AnalysisJobManagerTests : IDisposable
         Assert.Equal(countAtEnd, countAfterWait);
     }
 
+    // --- Issue #19: Race condition in Start() ---
+
+    [Fact]
+    public async Task Start_ConcurrentCalls_ExactlyOneProcessLaunches()
+    {
+        var factory = new ControllableFakeProcessFactory();
+        var manager = Build(factory);
+
+        var barrier = new Barrier(2);
+        var exceptions = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+
+        var t1 = Task.Run(() =>
+        {
+            barrier.SignalAndWait();
+            try { manager.Start("run1", "/input/tori.m2"); }
+            catch (Exception ex) { exceptions.Add(ex); }
+        });
+        var t2 = Task.Run(() =>
+        {
+            barrier.SignalAndWait();
+            try { manager.Start("run1", "/input/tori.m2"); }
+            catch (Exception ex) { exceptions.Add(ex); }
+        });
+
+        await Task.WhenAll(t1, t2);
+
+        Assert.Equal(1, factory.StartCount);
+        factory.LastProcess?.Release(0, "");
+        await manager.WaitAsync();
+    }
+
+    [Fact]
+    public async Task Start_AfterStop_DrainsOldTaskBeforeStartingNew()
+    {
+        var factory = new ControllableFakeProcessFactory();
+        var manager = Build(factory);
+
+        manager.Start("run1", "/input/tori.m2");
+        var oldProcess = factory.LastProcess!;
+        oldProcess.HoldTeardown(); // prevent teardown from completing until we say so
+
+        manager.Stop(); // cancels CTS; old task is now stuck in teardown hold
+
+        // Run Start("run2") on a background thread so we can control teardown timing
+        var startTask = Task.Run(() => manager.Start("run2", "/input/tori.m2"));
+
+        // Give startTask time to reach the drain/throw point
+        await Task.Delay(50);
+
+        // Release the old teardown — with fix this unblocks the drain, then "run2" starts
+        // Without fix, startTask has already thrown InvalidOperationException (status was Running)
+        oldProcess.ReleaseTeardown();
+
+        await startTask; // throws if Start("run2") threw InvalidOperationException
+        factory.LastProcess!.Release(0, "");
+        await manager.WaitAsync();
+
+        Assert.Equal(JobStatus.Complete, manager.GetState().Status);
+        Assert.Equal("run2", manager.GetState().RunName);
+    }
+
     // --- Bug #56: run_paused event ---
 
     [Fact]

--- a/src/ExtShiftingApp.Tests/M2/FakeProcessFactory.cs
+++ b/src/ExtShiftingApp.Tests/M2/FakeProcessFactory.cs
@@ -22,20 +22,40 @@ public class ControllableFakeProcess : IRunningProcess
         _gate.TrySetResult();
     }
 
+    private TaskCompletionSource? _teardownHold;
+
+    /// <summary>
+    /// When set before Kill/Stop, WaitForExitAsync will block at the cancellation point
+    /// until ReleaseTeardown() is called. Used to reliably test the stop/restart race.
+    /// </summary>
+    public void HoldTeardown() => _teardownHold = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+    public void ReleaseTeardown() => _teardownHold?.TrySetResult();
+
     public void Kill() { WasKilled = true; _gate.TrySetCanceled(); }
     public Task SendInputAsync(string line, CancellationToken ct = default) { InputLines.Add(line); return Task.CompletedTask; }
     public async Task WaitForExitAsync(CancellationToken ct)
     {
         await using var _ = ct.Register(() => _gate.TrySetCanceled());
-        await _gate.Task;
+        try
+        {
+            await _gate.Task;
+        }
+        catch (OperationCanceledException) when (_teardownHold is not null)
+        {
+            await _teardownHold.Task; // hold here until ReleaseTeardown() is called
+            throw;
+        }
     }
 }
 
 public class ControllableFakeProcessFactory : IProcessFactory
 {
     public ControllableFakeProcess? LastProcess { get; private set; }
+    public int StartCount { get; private set; }
+
     public IRunningProcess Start(string executable, string arguments, string workingDirectory, bool redirectStdin = false)
     {
+        StartCount++;
         LastProcess = new ControllableFakeProcess();
         return LastProcess;
     }

--- a/src/ExtShiftingApp/Analysis/AnalysisJobManager.cs
+++ b/src/ExtShiftingApp/Analysis/AnalysisJobManager.cs
@@ -9,6 +9,7 @@ public class AnalysisJobManager(M2ProcessRunner m2, string m2RepoPath, string ou
     private JobState _state = TryLoadPersistedState(outputPath) ?? JobState.Initial;
     private CancellationTokenSource? _cts;
     private Task _runTask = Task.CompletedTask;
+    private readonly object _lock = new();
     private readonly List<string> _outputLog = [];
     private readonly List<EventHandler<string>> _subscribers = [];
     private readonly QueueStateReader _queueReader = new();
@@ -27,13 +28,27 @@ public class AnalysisJobManager(M2ProcessRunner m2, string m2RepoPath, string ou
 
     public void Start(string runName, string inputFilePath, BatchParameters? batch = null)
     {
-        if (_state.Status == JobStatus.Running)
-            throw new InvalidOperationException("A job is already running.");
+        Task priorTask;
+        lock (_lock)
+        {
+            if (_state.Status == JobStatus.Running && (_cts == null || !_cts.IsCancellationRequested))
+                throw new InvalidOperationException("A job is already running.");
+            priorTask = _runTask;
+        }
 
-        _outputLog.Clear();
-        _runPausedSeen = false;
-        _cts = new CancellationTokenSource();
-        _state = JobState.Initial with { RunName = runName, Status = JobStatus.Running };
+        // Drain any in-flight teardown from a prior Stop() before mutating shared state
+        priorTask.GetAwaiter().GetResult();
+
+        lock (_lock)
+        {
+            if (_state.Status == JobStatus.Running)
+                throw new InvalidOperationException("A job is already running.");
+            _outputLog.Clear();
+            _runPausedSeen = false;
+            _cts = new CancellationTokenSource();
+            _state = JobState.Initial with { RunName = runName, Status = JobStatus.Running };
+        }
+
         PersistState();
         _runTask = RunQueueAsync(runName, inputFilePath, batch ?? new BatchParameters(), _cts.Token);
     }

--- a/src/ExtShiftingApp/wwwroot/index.html
+++ b/src/ExtShiftingApp/wwwroot/index.html
@@ -122,6 +122,7 @@
   <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.min.js"></script>
   <script>
     let replInitialised = false;
+    let currentEs = null;
 
     function showTab(name, btn) {
       document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
@@ -167,7 +168,9 @@
       log.classList.remove('hidden');
       status.style.color = '#888';
 
-      const es = new EventSource('/analysis/stream');
+      if (currentEs) { currentEs.close(); currentEs = null; }
+      currentEs = new EventSource('/analysis/stream');
+      const es = currentEs;
       es.onmessage = e => {
         const data = JSON.parse(e.data);
         if (data.type === 'm2_output') {
@@ -192,6 +195,7 @@
     }
 
     async function stopAnalysis() {
+      if (currentEs) { currentEs.close(); currentEs = null; }
       await fetch('/analysis/stop', { method: 'POST' });
       const log = document.getElementById('analysis-log');
       log.textContent = '';


### PR DESCRIPTION
## Summary

- Guards `Start()` with a lock and drains any in-flight teardown from a prior `Stop()` before mutating shared state, preventing concurrent calls from both passing the running-check
- Tracks the active `EventSource` in a module-scoped variable; closes it in `stopAnalysis()` and at the top of `startAnalysis()`, eliminating the UI log doubling on stop→start

## Test plan

- [ ] Start analysis → stop → start again (different name): each log item appears exactly once
- [ ] Concurrent `POST /analysis/start` while running returns HTTP 4xx; first run continues normally
- [ ] Status endpoint after stop/restart reflects the new run's state and run name
- [ ] `dotnet test` passes
- [ ] No browser console errors

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)