### PR TITLE
fix #62 #63: graceful Stop() via signal file + live GetState() counts

### DIFF
--- a/src/ExtShiftingApp.Tests/Analysis/AnalysisJobManagerTests.cs
+++ b/src/ExtShiftingApp.Tests/Analysis/AnalysisJobManagerTests.cs
@@ -25,10 +25,12 @@ public class AnalysisJobManagerTests : IDisposable
     }
 
     private AnalysisJobManager Build(FakeProcessFactory fake) =>
-        new(new M2ProcessRunner(fake, _m2Dir), _m2Dir, _outDir);
+        new(new M2ProcessRunner(fake, _m2Dir), _m2Dir, _outDir,
+            graceTimeout: TimeSpan.FromMilliseconds(50));
 
     private AnalysisJobManager Build(ControllableFakeProcessFactory factory) =>
-        new(new M2ProcessRunner(factory, _m2Dir), _m2Dir, _outDir);
+        new(new M2ProcessRunner(factory, _m2Dir), _m2Dir, _outDir,
+            graceTimeout: TimeSpan.FromMilliseconds(50));
 
     [Fact]
     public async Task Start_CompletedJob_TransitionsToComplete()
@@ -432,6 +434,175 @@ public class AnalysisJobManagerTests : IDisposable
         var countAfterWait = received.Count(line => line.Contains("queue_state"));
 
         Assert.Equal(countAtEnd, countAfterWait);
+    }
+
+    // --- Issue #63: stale status counts ---
+
+    [Fact]
+    public async Task PollingTimer_FiresImmediatelyOnRunStart_EmitsQueueStateSSE()
+    {
+        // Fails before fix: dueTime was _pollingInterval (60s), so no SSE fires in 100ms.
+        // Passes after fix: dueTime = TimeSpan.Zero, timer fires immediately.
+        var blockingFake = new ControllableFakeProcessFactory();
+        var received = new List<string>();
+        var manager = new AnalysisJobManager(
+            new M2ProcessRunner(blockingFake, _m2Dir), _m2Dir, _outDir,
+            pollingInterval: TimeSpan.FromSeconds(60),  // long — won't auto-repeat within test
+            graceTimeout: TimeSpan.FromMilliseconds(50));
+        manager.Subscribe((_, line) => received.Add(line));
+
+        var runDir = Path.Combine(_outDir, "my-run");
+        Directory.CreateDirectory(Path.Combine(runDir, "pending"));
+        Directory.CreateDirectory(Path.Combine(runDir, "done"));
+        File.WriteAllText(Path.Combine(runDir, "pending", "0001"),
+            "new HashTable from {\n  \"depth\" => 0,\n}");
+
+        manager.Start("my-run", "/input/tori.m2");
+        await Task.Delay(100); // well under 60s pollingInterval — only fires if dueTime=0
+
+        Assert.Contains(received, line => line.Contains("queue_state"));
+
+        blockingFake.LastProcess!.Release(0, "");
+        await manager.WaitAsync();
+    }
+
+    [Fact]
+    public async Task Start_ResetsLastPolledState_AllowsFirstPollToBroadcastOnRestart()
+    {
+        // Fails before fix: _lastPolledState not cleared on Start(), so same counts are suppressed.
+        // Passes after fix: _lastPolledState = null reset in Start().
+        var received = new List<string>();
+        var blockingFake = new ControllableFakeProcessFactory();
+        var manager = new AnalysisJobManager(
+            new M2ProcessRunner(blockingFake, _m2Dir), _m2Dir, _outDir,
+            pollingInterval: TimeSpan.FromHours(1),
+            graceTimeout: TimeSpan.FromMilliseconds(50));
+        manager.Subscribe((_, line) => received.Add(line));
+
+        // Run A — seed 1 pending item
+        var runDirA = Path.Combine(_outDir, "run-a");
+        Directory.CreateDirectory(Path.Combine(runDirA, "pending"));
+        Directory.CreateDirectory(Path.Combine(runDirA, "done"));
+        File.WriteAllText(Path.Combine(runDirA, "pending", "0001"),
+            "new HashTable from {\n  \"depth\" => 0,\n}");
+
+        manager.Start("run-a", "/input/tori.m2");
+        await Task.Delay(50); // let initial timer fire (dueTime=0) — establishes _lastPolledState={1,0}
+        blockingFake.LastProcess!.Release(0, "EVENT:{\"type\":\"run_paused\"}");
+        await manager.WaitAsync();
+
+        var countAfterRunA = received.Count(l => l.Contains("queue_state"));
+
+        // Run B — same queue state (1 pending item) to expose the stale _lastPolledState bug
+        var runDirB = Path.Combine(_outDir, "run-b");
+        Directory.CreateDirectory(Path.Combine(runDirB, "pending"));
+        Directory.CreateDirectory(Path.Combine(runDirB, "done"));
+        File.WriteAllText(Path.Combine(runDirB, "pending", "0001"),
+            "new HashTable from {\n  \"depth\" => 0,\n}");
+
+        manager.Start("run-b", "/input/tori.m2");
+        // Immediately call FirePollForTest — should broadcast because _lastPolledState was reset
+        manager.FirePollForTest();
+
+        Assert.True(received.Count(l => l.Contains("queue_state")) > countAfterRunA,
+            "_lastPolledState should be reset on Start() so re-run with same counts still broadcasts");
+
+        blockingFake.LastProcess!.Release(0, "");
+        await manager.WaitAsync();
+    }
+
+    [Fact]
+    public async Task GetState_ReturnsLiveDiskCounts_BetweenPollFireings()
+    {
+        // Fails before fix: GetState() returns stale _state snapshot.
+        // Passes after fix: GetState() overlays live _queueReader.Read() when Running.
+        var blockingFake = new ControllableFakeProcessFactory();
+        var manager = new AnalysisJobManager(
+            new M2ProcessRunner(blockingFake, _m2Dir), _m2Dir, _outDir,
+            pollingInterval: TimeSpan.FromMilliseconds(30),
+            graceTimeout: TimeSpan.FromMilliseconds(50));
+
+        var runDir = Path.Combine(_outDir, "my-run");
+        var pendingDir = Directory.CreateDirectory(Path.Combine(runDir, "pending")).FullName;
+        var doneDir = Directory.CreateDirectory(Path.Combine(runDir, "done")).FullName;
+        File.WriteAllText(Path.Combine(pendingDir, "0001"),
+            "new HashTable from {\n  \"depth\" => 0,\n}");
+
+        manager.Start("my-run", "/input/tori.m2");
+        await Task.Delay(50); // let timer fire once — _lastPolledState = {pending:1}
+
+        // Simulate M2 completing the item between poll firings
+        File.Move(Path.Combine(pendingDir, "0001"), Path.Combine(doneDir, "0001"));
+
+        // GetState() should reflect current disk state immediately (no FirePollForTest needed)
+        var state = manager.GetState();
+        Assert.Equal(0, state.PendingCount);
+        Assert.Equal(1, state.DoneCount);
+
+        blockingFake.LastProcess!.Release(0, "");
+        await manager.WaitAsync();
+    }
+
+    // --- Issue #62: Stop() hard-kills M2 mid-item ---
+
+    [Fact]
+    public async Task Stop_WritesStopRequestedFile_InsteadOfImmediateCancellation()
+    {
+        // Fails before fix: Stop() cancels CTS immediately — run completes before file check.
+        // Passes after fix: Stop() writes file + schedules grace cancel.
+        var blockingFake = new ControllableFakeProcessFactory();
+        var manager = new AnalysisJobManager(
+            new M2ProcessRunner(blockingFake, _m2Dir), _m2Dir, _outDir,
+            graceTimeout: TimeSpan.FromSeconds(30)); // long grace — won't fire during test
+
+        manager.Start("my-run", "/input/tori.m2");
+
+        manager.Stop();
+
+        // Signal file should exist
+        Assert.True(File.Exists(Path.Combine(_outDir, "my-run", "stop_requested")));
+
+        // Run should still be in progress (not immediately cancelled)
+        await Task.Delay(20);
+        Assert.False(manager.WaitAsync().IsCompleted,
+            "Run should not complete immediately — CTS is not cancelled until grace timeout");
+
+        // Cleanup: release naturally (simulating M2 finishing current item and seeing signal)
+        blockingFake.LastProcess!.Release(0, "EVENT:{\"type\":\"run_paused\"}");
+        await manager.WaitAsync();
+        Assert.Equal(JobStatus.Paused, manager.GetState().Status);
+    }
+
+    [Fact]
+    public async Task Stop_ItemInFlight_ItemDoneReceivedBeforePaused_KillNeverCalled()
+    {
+        // Fails before fix: Stop() cancels CTS → process killed → item_done never emitted.
+        // Passes after fix: Stop() writes file; process runs to natural exit; item_done is received.
+        var blockingFake = new ControllableFakeProcessFactory();
+        var manager = new AnalysisJobManager(
+            new M2ProcessRunner(blockingFake, _m2Dir), _m2Dir, _outDir,
+            graceTimeout: TimeSpan.FromSeconds(30));
+        var received = new List<string>();
+        manager.Subscribe((_, line) => received.Add(line));
+
+        manager.Start("my-run", "/input/tori.m2");
+        var process = blockingFake.LastProcess!;
+
+        // M2 emits item_started — item is now in-flight
+        process.EmitOutput("EVENT:{\"type\":\"item_started\",\"item\":\"0001\",\"depth\":0,\"parent\":\"seed\"}");
+
+        // Stop() called while item is in-flight — should NOT kill process immediately
+        manager.Stop();
+
+        // M2 finishes the current item naturally, then sees stop_requested and exits
+        process.Release(0,
+            "EVENT:{\"type\":\"item_done\",\"item\":\"0001\",\"splits\":2}\n" +
+            "EVENT:{\"type\":\"run_paused\"}");
+        await manager.WaitAsync();
+
+        Assert.Contains(received, l => l.Contains("item_done"));
+        Assert.Equal(JobStatus.Paused, manager.GetState().Status);
+        Assert.False(process.WasKilled, "M2 process should not be hard-killed when stop_requested signal is used");
     }
 
     // --- Issue #19: Race condition in Start() ---

--- a/src/ExtShiftingApp.Tests/Analysis/AnalysisJobManagerTests.cs
+++ b/src/ExtShiftingApp.Tests/Analysis/AnalysisJobManagerTests.cs
@@ -25,12 +25,10 @@ public class AnalysisJobManagerTests : IDisposable
     }
 
     private AnalysisJobManager Build(FakeProcessFactory fake) =>
-        new(new M2ProcessRunner(fake, _m2Dir), _m2Dir, _outDir,
-            graceTimeout: TimeSpan.FromMilliseconds(50));
+        new(new M2ProcessRunner(fake, _m2Dir), _m2Dir, _outDir);
 
     private AnalysisJobManager Build(ControllableFakeProcessFactory factory) =>
-        new(new M2ProcessRunner(factory, _m2Dir), _m2Dir, _outDir,
-            graceTimeout: TimeSpan.FromMilliseconds(50));
+        new(new M2ProcessRunner(factory, _m2Dir), _m2Dir, _outDir);
 
     [Fact]
     public async Task Start_CompletedJob_TransitionsToComplete()
@@ -79,6 +77,9 @@ public class AnalysisJobManagerTests : IDisposable
 
         manager.Start("my-run", "/input/tori.m2");
         manager.Stop();
+
+        // Stop() no longer hard-kills; M2 must exit naturally after seeing the signal.
+        factory.LastProcess!.Release(0, "EVENT:{\"type\":\"run_paused\"}");
         await manager.WaitAsync();
 
         Assert.Equal(JobStatus.Paused, manager.GetState().Status);
@@ -236,6 +237,7 @@ public class AnalysisJobManagerTests : IDisposable
 
         manager.Start("my-run", "/input/tori.m2");
         manager.Stop();
+        factory.LastProcess!.Release(0, "EVENT:{\"type\":\"run_paused\"}");
         await manager.WaitAsync();
 
         Assert.Equal(JobStatus.Paused, manager.GetState().Status);
@@ -250,6 +252,7 @@ public class AnalysisJobManagerTests : IDisposable
         // Start and stop to reach Paused
         manager.Start("my-run", "/input/tori.m2");
         manager.Stop();
+        factory.LastProcess!.Release(0, "EVENT:{\"type\":\"run_paused\"}");
         await manager.WaitAsync();
         Assert.Equal(JobStatus.Paused, manager.GetState().Status);
 
@@ -299,9 +302,11 @@ public class AnalysisJobManagerTests : IDisposable
         manager.SetPausedState("run-A");
         Assert.True(manager.GetOutputLog().Count > 0, "Precondition: log should have lines");
 
-        // Resume — factory creates a new blocking process; log should be cleared before it runs
+        // Resume — factory creates a new blocking process; prior output must not appear again
         manager.Resume("run-A");
-        Assert.Equal(0, manager.GetOutputLog().Count);
+        // The immediate poll timer (dueTime=0) may add a queue_state line before this assertion,
+        // so we check for absence of old content rather than exact count == 0.
+        Assert.DoesNotContain(manager.GetOutputLog(), l => l.Contains("old output"));
 
         factory.LastProcess!.Release(0, "");
         await manager.WaitAsync();
@@ -447,8 +452,7 @@ public class AnalysisJobManagerTests : IDisposable
         var received = new List<string>();
         var manager = new AnalysisJobManager(
             new M2ProcessRunner(blockingFake, _m2Dir), _m2Dir, _outDir,
-            pollingInterval: TimeSpan.FromSeconds(60),  // long — won't auto-repeat within test
-            graceTimeout: TimeSpan.FromMilliseconds(50));
+            pollingInterval: TimeSpan.FromSeconds(60)); // long — won't auto-repeat within test
         manager.Subscribe((_, line) => received.Add(line));
 
         var runDir = Path.Combine(_outDir, "my-run");
@@ -475,8 +479,7 @@ public class AnalysisJobManagerTests : IDisposable
         var blockingFake = new ControllableFakeProcessFactory();
         var manager = new AnalysisJobManager(
             new M2ProcessRunner(blockingFake, _m2Dir), _m2Dir, _outDir,
-            pollingInterval: TimeSpan.FromHours(1),
-            graceTimeout: TimeSpan.FromMilliseconds(50));
+            pollingInterval: TimeSpan.FromHours(1));
         manager.Subscribe((_, line) => received.Add(line));
 
         // Run A — seed 1 pending item
@@ -519,8 +522,7 @@ public class AnalysisJobManagerTests : IDisposable
         var blockingFake = new ControllableFakeProcessFactory();
         var manager = new AnalysisJobManager(
             new M2ProcessRunner(blockingFake, _m2Dir), _m2Dir, _outDir,
-            pollingInterval: TimeSpan.FromMilliseconds(30),
-            graceTimeout: TimeSpan.FromMilliseconds(50));
+            pollingInterval: TimeSpan.FromSeconds(10)); // long enough that only the initial dueTime=0 fires
 
         var runDir = Path.Combine(_outDir, "my-run");
         var pendingDir = Directory.CreateDirectory(Path.Combine(runDir, "pending")).FullName;
@@ -548,12 +550,10 @@ public class AnalysisJobManagerTests : IDisposable
     [Fact]
     public async Task Stop_WritesStopRequestedFile_InsteadOfImmediateCancellation()
     {
-        // Fails before fix: Stop() cancels CTS immediately — run completes before file check.
-        // Passes after fix: Stop() writes file + schedules grace cancel.
+        // Verifies Stop() writes stop_requested and does not immediately end the run.
         var blockingFake = new ControllableFakeProcessFactory();
         var manager = new AnalysisJobManager(
-            new M2ProcessRunner(blockingFake, _m2Dir), _m2Dir, _outDir,
-            graceTimeout: TimeSpan.FromSeconds(30)); // long grace — won't fire during test
+            new M2ProcessRunner(blockingFake, _m2Dir), _m2Dir, _outDir);
 
         manager.Start("my-run", "/input/tori.m2");
 
@@ -562,10 +562,10 @@ public class AnalysisJobManagerTests : IDisposable
         // Signal file should exist
         Assert.True(File.Exists(Path.Combine(_outDir, "my-run", "stop_requested")));
 
-        // Run should still be in progress (not immediately cancelled)
+        // Run should still be in progress — Stop() does not cancel CTS
         await Task.Delay(20);
         Assert.False(manager.WaitAsync().IsCompleted,
-            "Run should not complete immediately — CTS is not cancelled until grace timeout");
+            "Run should not complete immediately after Stop()");
 
         // Cleanup: release naturally (simulating M2 finishing current item and seeing signal)
         blockingFake.LastProcess!.Release(0, "EVENT:{\"type\":\"run_paused\"}");
@@ -580,8 +580,7 @@ public class AnalysisJobManagerTests : IDisposable
         // Passes after fix: Stop() writes file; process runs to natural exit; item_done is received.
         var blockingFake = new ControllableFakeProcessFactory();
         var manager = new AnalysisJobManager(
-            new M2ProcessRunner(blockingFake, _m2Dir), _m2Dir, _outDir,
-            graceTimeout: TimeSpan.FromSeconds(30));
+            new M2ProcessRunner(blockingFake, _m2Dir), _m2Dir, _outDir);
         var received = new List<string>();
         manager.Subscribe((_, line) => received.Add(line));
 
@@ -603,6 +602,39 @@ public class AnalysisJobManagerTests : IDisposable
         Assert.Contains(received, l => l.Contains("item_done"));
         Assert.Equal(JobStatus.Paused, manager.GetState().Status);
         Assert.False(process.WasKilled, "M2 process should not be hard-killed when stop_requested signal is used");
+    }
+
+    // --- Bug: Stop() hard-kills M2 mid-item when grace timeout fires ---
+
+    [Fact]
+    public async Task Stop_ItemTakesLongerThanGraceTimeout_ProcessNotKilledPrematurely()
+    {
+        // Before fix: Stop() scheduled CTS cancellation after a grace timeout, killing M2 mid-item.
+        // After fix: Stop() only writes stop_requested; CTS is never cancelled by Stop().
+        var blockingFake = new ControllableFakeProcessFactory();
+        var manager = new AnalysisJobManager(
+            new M2ProcessRunner(blockingFake, _m2Dir), _m2Dir, _outDir);
+
+        manager.Start("my-run", "/input/tori.m2");
+        var process = blockingFake.LastProcess!;
+
+        process.EmitOutput("EVENT:{\"type\":\"item_started\",\"item\":\"0001\",\"depth\":0,\"parent\":\"seed\"}");
+        manager.Stop();
+
+        // Wait well past the (old) grace timeout — item is still computing
+        await Task.Delay(150);
+
+        // Bug: WaitAsync() is already completed (CTS fired at 30ms, M2 killed)
+        // Fix: run is still in progress — Stop() did not cancel CTS
+        Assert.False(manager.WaitAsync().IsCompleted,
+            "Stop() must not kill M2 mid-item; run should still be in progress after grace timeout");
+
+        process.Release(0,
+            "EVENT:{\"type\":\"item_done\",\"item\":\"0001\",\"splits\":0}\n" +
+            "EVENT:{\"type\":\"run_paused\"}");
+        await manager.WaitAsync();
+
+        Assert.Equal(JobStatus.Paused, manager.GetState().Status);
     }
 
     // --- Issue #19: Race condition in Start() ---
@@ -644,21 +676,21 @@ public class AnalysisJobManagerTests : IDisposable
 
         manager.Start("run1", "/input/tori.m2");
         var oldProcess = factory.LastProcess!;
-        oldProcess.HoldTeardown(); // prevent teardown from completing until we say so
 
-        manager.Stop(); // cancels CTS; old task is now stuck in teardown hold
+        manager.Stop(); // writes stop_requested; does NOT cancel CTS
 
-        // Run Start("run2") on a background thread so we can control teardown timing
+        // Start("run2") on a background thread — should block draining run1, not throw
         var startTask = Task.Run(() => manager.Start("run2", "/input/tori.m2"));
 
-        // Give startTask time to reach the drain/throw point
-        await Task.Delay(50);
+        await Task.Delay(50); // give startTask time to reach the drain point
 
-        // Release the old teardown — with fix this unblocks the drain, then "run2" starts
-        // Without fix, startTask has already thrown InvalidOperationException (status was Running)
-        oldProcess.ReleaseTeardown();
+        Assert.False(startTask.IsCompleted,
+            "Start should block while draining the old run, not throw or complete immediately");
 
-        await startTask; // throws if Start("run2") threw InvalidOperationException
+        // Release run1 naturally (M2 sees signal and exits) — unblocks the drain
+        oldProcess.Release(0, "EVENT:{\"type\":\"run_paused\"}");
+
+        await startTask;
         factory.LastProcess!.Release(0, "");
         await manager.WaitAsync();
 

--- a/src/ExtShiftingApp.Tests/M2/FakeProcessFactory.cs
+++ b/src/ExtShiftingApp.Tests/M2/FakeProcessFactory.cs
@@ -31,6 +31,13 @@ public class ControllableFakeProcess : IRunningProcess
     public void HoldTeardown() => _teardownHold = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
     public void ReleaseTeardown() => _teardownHold?.TrySetResult();
 
+    /// <summary>Emits output lines to subscribers without releasing the process gate.</summary>
+    public void EmitOutput(string output)
+    {
+        foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            OutputReceived?.Invoke(this, line);
+    }
+
     public void Kill() { WasKilled = true; _gate.TrySetCanceled(); }
     public Task SendInputAsync(string line, CancellationToken ct = default) { InputLines.Add(line); return Task.CompletedTask; }
     public async Task WaitForExitAsync(CancellationToken ct)

--- a/src/ExtShiftingApp/Analysis/AnalysisJobManager.cs
+++ b/src/ExtShiftingApp/Analysis/AnalysisJobManager.cs
@@ -3,10 +3,9 @@ using ExtShiftingApp.M2;
 namespace ExtShiftingApp.Analysis;
 
 public class AnalysisJobManager(M2ProcessRunner m2, string m2RepoPath, string outputPath,
-    TimeSpan? pollingInterval = null, TimeSpan? graceTimeout = null)
+    TimeSpan? pollingInterval = null)
 {
     private readonly TimeSpan _pollingInterval = pollingInterval ?? TimeSpan.FromSeconds(60);
-    private readonly TimeSpan _graceTimeout    = graceTimeout    ?? TimeSpan.FromSeconds(30);
     private JobState _state = TryLoadPersistedState(outputPath) ?? JobState.Initial;
     private CancellationTokenSource? _cts;
     private Task _runTask = Task.CompletedTask;
@@ -74,8 +73,8 @@ public class AnalysisJobManager(M2ProcessRunner m2, string m2RepoPath, string ou
 
     /// <summary>
     /// Signals a graceful stop by writing a <c>stop_requested</c> file in the run directory.
-    /// M2's runQueue loop will detect the file, finish the current item, and exit cleanly.
-    /// A hard CTS cancellation fires after <c>_graceTimeout</c> as a safety fallback.
+    /// M2's runQueue loop detects the file between items, finishes the current item, and exits.
+    /// The run task completes naturally; no CTS cancellation is scheduled.
     /// </summary>
     public void Stop()
     {
@@ -86,14 +85,7 @@ public class AnalysisJobManager(M2ProcessRunner m2, string m2RepoPath, string ou
 
         var stopSignalPath = Path.Combine(outputPath, runName, "stop_requested");
         try { File.WriteAllText(stopSignalPath, ""); }
-        catch { /* run dir may not exist yet; grace-kill fallback handles it */ }
-
-        // Fallback hard kill after grace period — guards against M2 hanging indefinitely
-        var capturedCts = _cts;
-        _ = Task.Delay(_graceTimeout).ContinueWith(_ =>
-        {
-            if (_cts == capturedCts) capturedCts?.Cancel();
-        });
+        catch { /* run dir may not exist yet */ }
     }
 
     /// <summary>
@@ -146,6 +138,13 @@ public class AnalysisJobManager(M2ProcessRunner m2, string m2RepoPath, string ou
         }
         catch (OperationCanceledException)
         {
+            // CTS was cancelled externally (e.g. app shutdown). Clean up the signal file
+            // if M2 didn't consume it — prevents it from poisoning a subsequent Resume.
+            if (_state.RunName is not null)
+            {
+                var signal = Path.Combine(outputPath, _state.RunName, "stop_requested");
+                try { File.Delete(signal); } catch { }
+            }
             _state = _state with { Status = JobStatus.Paused };
         }
         catch (Exception ex)

--- a/src/ExtShiftingApp/Analysis/AnalysisJobManager.cs
+++ b/src/ExtShiftingApp/Analysis/AnalysisJobManager.cs
@@ -3,9 +3,10 @@ using ExtShiftingApp.M2;
 namespace ExtShiftingApp.Analysis;
 
 public class AnalysisJobManager(M2ProcessRunner m2, string m2RepoPath, string outputPath,
-    TimeSpan? pollingInterval = null)
+    TimeSpan? pollingInterval = null, TimeSpan? graceTimeout = null)
 {
     private readonly TimeSpan _pollingInterval = pollingInterval ?? TimeSpan.FromSeconds(60);
+    private readonly TimeSpan _graceTimeout    = graceTimeout    ?? TimeSpan.FromSeconds(30);
     private JobState _state = TryLoadPersistedState(outputPath) ?? JobState.Initial;
     private CancellationTokenSource? _cts;
     private Task _runTask = Task.CompletedTask;
@@ -15,8 +16,23 @@ public class AnalysisJobManager(M2ProcessRunner m2, string m2RepoPath, string ou
     private readonly QueueStateReader _queueReader = new();
     private QueueState? _lastPolledState;
     private bool _runPausedSeen;
+    private bool _stopRequested;
 
-    public JobState GetState() => _state;
+    public JobState GetState()
+    {
+        if (_state.Status == JobStatus.Running && _state.RunName is not null)
+        {
+            var runDir = Path.Combine(outputPath, _state.RunName);
+            var live = _queueReader.Read(runDir);
+            return _state with
+            {
+                PendingCount     = live.PendingCount,
+                DoneCount        = live.DoneCount,
+                CurrentItemDepth = live.CurrentItemDepth,
+            };
+        }
+        return _state;
+    }
 
     public IReadOnlyList<string> GetOutputLog() => _outputLog;
 
@@ -31,7 +47,8 @@ public class AnalysisJobManager(M2ProcessRunner m2, string m2RepoPath, string ou
         Task priorTask;
         lock (_lock)
         {
-            if (_state.Status == JobStatus.Running && (_cts == null || !_cts.IsCancellationRequested))
+            if (_state.Status == JobStatus.Running &&
+                (_cts == null || (!_cts.IsCancellationRequested && !_stopRequested)))
                 throw new InvalidOperationException("A job is already running.");
             priorTask = _runTask;
         }
@@ -45,6 +62,8 @@ public class AnalysisJobManager(M2ProcessRunner m2, string m2RepoPath, string ou
                 throw new InvalidOperationException("A job is already running.");
             _outputLog.Clear();
             _runPausedSeen = false;
+            _stopRequested = false;
+            _lastPolledState = null;
             _cts = new CancellationTokenSource();
             _state = JobState.Initial with { RunName = runName, Status = JobStatus.Running };
         }
@@ -53,7 +72,29 @@ public class AnalysisJobManager(M2ProcessRunner m2, string m2RepoPath, string ou
         _runTask = RunQueueAsync(runName, inputFilePath, batch ?? new BatchParameters(), _cts.Token);
     }
 
-    public void Stop() => _cts?.Cancel();
+    /// <summary>
+    /// Signals a graceful stop by writing a <c>stop_requested</c> file in the run directory.
+    /// M2's runQueue loop will detect the file, finish the current item, and exit cleanly.
+    /// A hard CTS cancellation fires after <c>_graceTimeout</c> as a safety fallback.
+    /// </summary>
+    public void Stop()
+    {
+        var runName = _state.RunName;
+        if (runName is null) return;
+
+        _stopRequested = true;
+
+        var stopSignalPath = Path.Combine(outputPath, runName, "stop_requested");
+        try { File.WriteAllText(stopSignalPath, ""); }
+        catch { /* run dir may not exist yet; grace-kill fallback handles it */ }
+
+        // Fallback hard kill after grace period — guards against M2 hanging indefinitely
+        var capturedCts = _cts;
+        _ = Task.Delay(_graceTimeout).ContinueWith(_ =>
+        {
+            if (_cts == capturedCts) capturedCts?.Cancel();
+        });
+    }
 
     /// <summary>
     /// Resumes a paused run. Exposed for testing via SetPausedState.
@@ -65,6 +106,8 @@ public class AnalysisJobManager(M2ProcessRunner m2, string m2RepoPath, string ou
 
         _outputLog.Clear();
         _runPausedSeen = false;
+        _stopRequested = false;
+        _lastPolledState = null;
         _cts = new CancellationTokenSource();
         _state = _state with { RunName = runName, Status = JobStatus.Running };
         PersistState();
@@ -82,7 +125,8 @@ public class AnalysisJobManager(M2ProcessRunner m2, string m2RepoPath, string ou
 
     private async Task RunQueueAsync(string runName, string? inputFilePath, BatchParameters batch, CancellationToken ct)
     {
-        using var pollTimer = new System.Threading.Timer(_ => Poll(), null, _pollingInterval, _pollingInterval);
+        // dueTime = TimeSpan.Zero: first poll fires immediately so SSE clients see counts right away
+        using var pollTimer = new System.Threading.Timer(_ => Poll(), null, TimeSpan.Zero, _pollingInterval);
         try
         {
             var scriptPath = Path.Combine(m2RepoPath, "scripts", "runQueue.m2");
@@ -153,8 +197,8 @@ public class AnalysisJobManager(M2ProcessRunner m2, string m2RepoPath, string ou
 
     private static string FormatBatchArgs(BatchParameters b)
     {
-        var itemCap  = b.ItemCap.HasValue        ? b.ItemCap.Value.ToString()                : "null";
-        var maxVerts = b.MaxVertexCount.HasValue  ? b.MaxVertexCount.Value.ToString()         : "null";
+        var itemCap  = b.ItemCap.HasValue        ? b.ItemCap.Value.ToString()                     : "null";
+        var maxVerts = b.MaxVertexCount.HasValue  ? b.MaxVertexCount.Value.ToString()              : "null";
         var timeout  = b.Timeout.HasValue         ? ((int)b.Timeout.Value.TotalSeconds).ToString() : "null";
         return $"{itemCap} {maxVerts} {timeout}";
     }


### PR DESCRIPTION
## Summary

Fixes two issues with `AnalysisJobManager`:

**#62 — Stop() hard-kills M2 mid-item**
- `Stop()` now writes a `stop_requested` signal file instead of cancelling the CTS
- M2's `runQueue` loop detects the file between items, finishes the in-flight item, emits `run_paused`, and exits cleanly
- The CTS is never cancelled by `Stop()`; `OperationCanceledException` is reserved for app-shutdown paths only, and the catch block now cleans up any residual `stop_requested` file

**#63 — Stale status counts**
- Timer `dueTime` changed to `TimeSpan.Zero` so the first poll fires immediately on run start (SSE clients see counts right away)
- `_lastPolledState` reset in `Start()` and `Resume()` so re-runs with the same counts still broadcast
- `GetState()` overlays live disk reads (`_queueReader.Read()`) when status is `Running`, so the HTTP endpoint reflects current state between timer firings

**Test infrastructure**
- `ControllableFakeProcess.EmitOutput()` added to send output lines without releasing the process gate
- All Stop()-related tests updated to release processes naturally (via `run_paused` event) instead of relying on CTS cancellation
- Removes `graceTimeout` constructor param (no longer needed)
- Updates the race-condition drain test (#19) to match new Stop() semantics

## Test plan

- [ ] `dotnet test` — all C# tests pass
- [ ] Manual: start a run, POST `/stop`, verify the in-flight item completes before status flips to `Paused`
- [ ] Manual: check `/state` mid-run returns live pending/done counts without waiting for the next poll tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)