### PR TITLE
feat: M2 integration test runner + iterative analysis test scripts (closes #70)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,15 +18,13 @@ Do NOT add: architecture explanations, C# internals, test philosophy, module des
 
 When using the `/tdd` skill (or doing any test-driven work) and the changes involve M2 code (files under `m2/ext-shifting/`):
 
-- Always include M2 tests as part of the TDD cycle.
-- M2 tests cannot be run automatically — a human must run them in an M2 terminal.
-- After writing or modifying M2 test code, tell the user exactly what command to run, e.g.:
+- M2 tests are integrated into the dotnet test suite as integration tests and run via `dotnet test`.
+- Do NOT run the full suite on every red-green cycle — M2 integration tests are slow. Run targeted tests during the cycle using filters, e.g.:
   ```
-  loadPackage "ext-shifting"; check "ext-shifting"
+  dotnet test --filter "FullyQualifiedName~SomeSpecificTest"
   ```
-  or the specific test file/block to evaluate.
-- Wait for the user to report results before marking the M2 test step complete.
-- Do NOT consider the TDD cycle done until M2 tests have been confirmed passing by the user.
+- Run the full suite (`dotnet test`) only at the end of a TDD cycle to confirm nothing is broken.
+- Do NOT consider the TDD cycle done until the full suite passes.
 
 ## Ubiquitous Language
 

--- a/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
+++ b/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
@@ -58,4 +58,25 @@ public class M2IntegrationTests
     [Fact]
     [Trait("Category", "M2Integration")]
     public Task QueueOps_RunQueue_Options_Passes() => RunScript("queueOps-runQueue-options.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
+    public Task TestProjectivePlane_Passes() => RunScript("testProjectivePlane.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
+    public Task TestTorus_Passes() => RunScript("testTorus.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
+    public Task TestKleinBottle_Passes() => RunScript("testKleinBottle.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
+    public async Task M2LibChecks_PassAllUnitTests()
+    {
+        if (!Runner.IsAvailable()) return; // skip: M2 not available
+        var result = await Runner.RunCommandAsync("check \"ext-shifting\"", M2Root);
+        Assert.True(result.Success, result.Output);
+    }
 }

--- a/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
+++ b/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
@@ -79,4 +79,13 @@ public class M2IntegrationTests
         var result = await Runner.RunCommandAsync("check \"ExtShifting\"", M2Root);
         Assert.True(result.Success, result.Output);
     }
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
+    public async Task FailingScript_ReportsFailure()
+    {
+        if (!Runner.IsAvailable()) return; // skip: M2 not available
+        var result = await Runner.RunCommandAsync("assert false", M2Root);
+        Assert.False(result.Success, "Expected a failing M2 assertion to be reported as failure");
+    }
 }

--- a/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
+++ b/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
@@ -1,0 +1,61 @@
+using ExtShiftingApp.M2;
+
+namespace ExtShiftingApp.Tests;
+
+public class M2IntegrationTests
+{
+    private static string M2Root =>
+        Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../m2/ext-shifting"));
+
+    private static string TestsDir => Path.Combine(M2Root, "tests");
+
+    private static readonly WslAwareM2Runner Runner = new();
+
+    private static void SkipIfUnavailable()
+    {
+        if (!Runner.IsAvailable()) return;
+    }
+
+    private static async Task RunScript(string scriptName)
+    {
+        if (!Runner.IsAvailable()) return; // skip: M2 not available
+        var result = await Runner.RunScriptAsync(Path.Combine(TestsDir, scriptName));
+        Assert.True(result.Success, result.Output);
+    }
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
+    public Task CriticalRegions_Tori_Passes() => RunScript("criticalRegions-tori.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
+    public Task CriticalRegions_KleinBottle_Passes() => RunScript("criticalRegions-kb.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
+    public Task CriticalRegions_Kb25_BadSplit_Passes() => RunScript("criticalRegions-kb25-badSplit.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
+    public Task CriticalRegions_Kb25_ExemptSplits_Passes() => RunScript("criticalRegions-kb25-exemptSplits.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
+    public Task AnalyzeIteration_Kb25_Passes() => RunScript("analyzeIteration-kb25.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
+    public Task QueueOps_ProcessItem_Moves_Passes() => RunScript("queueOps-processItem-moves.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
+    public Task QueueOps_ProcessItem_Parent_Passes() => RunScript("queueOps-processItem-parent.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
+    public Task QueueOps_RunQueue_ItemCap_Passes() => RunScript("queueOps-runQueue-itemCap.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
+    public Task QueueOps_RunQueue_Options_Passes() => RunScript("queueOps-runQueue-options.m2");
+}

--- a/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
+++ b/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
@@ -19,7 +19,7 @@ public class M2IntegrationTests
     private static async Task RunScript(string scriptName)
     {
         if (!Runner.IsAvailable()) return; // skip: M2 not available
-        var result = await Runner.RunScriptAsync(Path.Combine(TestsDir, scriptName));
+        var result = await Runner.RunScriptAsync(Path.Combine(TestsDir, scriptName), M2Root);
         Assert.True(result.Success, result.Output);
     }
 
@@ -76,7 +76,7 @@ public class M2IntegrationTests
     public async Task M2LibChecks_PassAllUnitTests()
     {
         if (!Runner.IsAvailable()) return; // skip: M2 not available
-        var result = await Runner.RunCommandAsync("check \"ext-shifting\"", M2Root);
+        var result = await Runner.RunCommandAsync("check \"ExtShifting\"", M2Root);
         Assert.True(result.Success, result.Output);
     }
 }

--- a/src/ExtShiftingApp/M2/WslAwareM2Runner.cs
+++ b/src/ExtShiftingApp/M2/WslAwareM2Runner.cs
@@ -1,0 +1,104 @@
+namespace ExtShiftingApp.M2;
+
+/// <summary>
+/// WSL-aware M2 runner for test infrastructure. Owns all M2 invocation complexity:
+/// reads M2_EXECUTABLE env var, falls back to WSL on Windows, translates paths.
+/// </summary>
+public class WslAwareM2Runner
+{
+    private readonly IProcessFactory _processFactory;
+
+    public WslAwareM2Runner() : this(new SystemProcessFactory()) { }
+
+    internal WslAwareM2Runner(IProcessFactory processFactory)
+    {
+        _processFactory = processFactory;
+    }
+
+    private static bool IsWindows => OperatingSystem.IsWindows();
+
+    private string Executable
+    {
+        get
+        {
+            var envVar = Environment.GetEnvironmentVariable("M2_EXECUTABLE");
+            if (!string.IsNullOrEmpty(envVar)) return envVar;
+            return IsWindows ? "wsl.exe" : "M2";
+        }
+    }
+
+    private bool UseWsl => string.IsNullOrEmpty(Environment.GetEnvironmentVariable("M2_EXECUTABLE")) && IsWindows;
+
+    /// <summary>
+    /// Translates a Windows path (C:\...) to a WSL path (/mnt/c/...) when running under WSL.
+    /// </summary>
+    private static string ToWslPath(string windowsPath)
+    {
+        if (windowsPath.Length >= 3 && windowsPath[1] == ':')
+        {
+            var driveLetter = char.ToLowerInvariant(windowsPath[0]);
+            var rest = windowsPath[2..].Replace('\\', '/');
+            return $"/mnt/{driveLetter}{rest}";
+        }
+        return windowsPath.Replace('\\', '/');
+    }
+
+    private string BuildArguments(string scriptPath)
+    {
+        if (UseWsl)
+        {
+            var wslPath = ToWslPath(scriptPath);
+            return $"M2 --script \"{wslPath}\"";
+        }
+        return $"--script \"{scriptPath}\"";
+    }
+
+    private string WorkingDirectory(string scriptPath)
+    {
+        var dir = Path.GetDirectoryName(scriptPath) ?? ".";
+        // For WSL runs, working directory is the parent of the script in WSL form
+        // but ProcessFactory's working directory is the host path; WSL resolves relative to CWD.
+        // We pass the host path and let the shell resolve it.
+        return Path.GetDirectoryName(Path.GetFullPath(scriptPath)) ?? ".";
+    }
+
+    public async Task<M2Result> RunScriptAsync(string scriptPath)
+    {
+        const int maxOutputLines = 100;
+        var recentLines = new Queue<string>();
+        var workDir = WorkingDirectory(scriptPath);
+        var process = _processFactory.Start(Executable, BuildArguments(scriptPath), workDir);
+
+        void capture(string line)
+        {
+            if (recentLines.Count >= maxOutputLines) recentLines.Dequeue();
+            recentLines.Enqueue(line);
+        }
+
+        process.OutputReceived += (_, line) => capture(line);
+        process.ErrorReceived += (_, line) => capture(line);
+
+        await process.WaitForExitAsync(CancellationToken.None);
+
+        return new M2Result(process.ExitCode == 0, string.Join("\n", recentLines), process.ExitCode);
+    }
+
+    /// <summary>
+    /// Returns false (never throws) when M2 is unreachable. Used as a skip gate in tests.
+    /// </summary>
+    public bool IsAvailable()
+    {
+        try
+        {
+            var exe = Executable;
+            var args = UseWsl ? "M2 --version" : "--version";
+            var process = _processFactory.Start(exe, args, ".");
+            process.WaitForExitAsync(CancellationToken.None).GetAwaiter().GetResult();
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/ExtShiftingApp/M2/WslAwareM2Runner.cs
+++ b/src/ExtShiftingApp/M2/WslAwareM2Runner.cs
@@ -53,20 +53,11 @@ public class WslAwareM2Runner
         return $"--script \"{scriptPath}\"";
     }
 
-    private string WorkingDirectory(string scriptPath)
-    {
-        var dir = Path.GetDirectoryName(scriptPath) ?? ".";
-        // For WSL runs, working directory is the parent of the script in WSL form
-        // but ProcessFactory's working directory is the host path; WSL resolves relative to CWD.
-        // We pass the host path and let the shell resolve it.
-        return Path.GetDirectoryName(Path.GetFullPath(scriptPath)) ?? ".";
-    }
-
-    public async Task<M2Result> RunScriptAsync(string scriptPath)
+    public async Task<M2Result> RunScriptAsync(string scriptPath, string? workingDirectory = null)
     {
         const int maxOutputLines = 100;
         var recentLines = new Queue<string>();
-        var workDir = WorkingDirectory(scriptPath);
+        var workDir = workingDirectory ?? Path.GetDirectoryName(Path.GetFullPath(scriptPath)) ?? ".";
         var process = _processFactory.Start(Executable, BuildArguments(scriptPath), workDir);
 
         void capture(string line)
@@ -81,6 +72,24 @@ public class WslAwareM2Runner
         await process.WaitForExitAsync(CancellationToken.None);
 
         return new M2Result(process.ExitCode == 0, string.Join("\n", recentLines), process.ExitCode);
+    }
+
+    /// <summary>
+    /// Runs an M2 command string from the given working directory.
+    /// Writes the code to a temp script and invokes it.
+    /// </summary>
+    public async Task<M2Result> RunCommandAsync(string m2Code, string workingDirectory)
+    {
+        var tmpScript = Path.Combine(Path.GetTempPath(), $"m2_{Guid.NewGuid():N}.m2");
+        try
+        {
+            await File.WriteAllTextAsync(tmpScript, m2Code);
+            return await RunScriptAsync(tmpScript, workingDirectory);
+        }
+        finally
+        {
+            File.Delete(tmpScript);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Adds `WslAwareM2Runner` (C#) to invoke M2 via WSL on Windows or directly on Linux/Docker
- Adds `M2IntegrationTests` xUnit class with tests for torus, Klein bottle, and projective plane iterative analysis termination, plus a `check "ext-shifting"` test
- Bumps `m2/ext-shifting` submodule to pick up `testTorus.m2`, `testKleinBottle.m2`, and `testProjectivePlane.m2`
- Updates `CLAUDE.md` TDD guidance: M2 tests now run via `dotnet test --filter` during red-green cycles; full suite only at end of cycle

## Test plan

- [ ] `dotnet test --filter "Category=M2Integration"` — all M2 integration tests pass (requires M2/WSL)
- [ ] `dotnet test` — full suite passes, M2 tests skipped gracefully if M2 unavailable
- [ ] `dotnet test --filter "FullyQualifiedName~FailingScript"` — failure detection test passes

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)