### PR TITLE
fix(#81): suppress trivial disk critical region from analyzeIteration

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,8 +1,6 @@
 # Backlog
 
-- **Queue analysis critical region output** `[small] [high]`: The queue-based analysis does not capture or persist the critical region data (topological type and boundary size) that the old batch analysis recorded. Spans the M2 computation layer and the C# surfacing layer.
-  - **Capture critical regions per item in M2 queue processor** `[small] [high]`: `processQueueItem` discards the `critRegions` return value from `analyzeIteration`; critical region data is not written to any output file.
-  - **Surface critical region data via C# API** `[small] [mid]`: Once the M2 queue processor writes critical region data to files, the C# layer does not read or expose it. Depends on the M2 capture item.
+- **Compile done triangulations into a results file** `[medium] [high]`: Once critical regions and other per-item data are captured in done files, provide a mechanism to compile all done triangulation data into a single human-readable file that makes it easy to observe and review the results of a completed analysis run.
 
 - **M2 output observability** `[medium] [mid]`: The app and M2 codebase provide limited visibility into computation state, timing, and failure modes during a run.
   - **Output line timestamps (M2 + app layer)** `[medium] [mid]`: M2 output lines carry no timing information, making it impossible to distinguish real-time streaming from a burst of output at process exit. This prevents verification that the buffered-output fix is actually working. Two timestamp sources are needed: M2-side (when the line was emitted) and C# side (when `OutputReceived` fired), surfaced through the SSE stream and displayed in the live log.

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -72,6 +72,21 @@ Canonical terminology for the ext-shifting-app codebase: backend, frontend, API,
 
 ---
 
+### M2 Queue (App-Layer References)
+
+| Term | Definition | Aliases to avoid |
+|------|------------|-----------------|
+| **Analysis queue** | The persistent file-based work queue managed by `queueOps.m2`. Lives under the run output directory as two subdirectories: `pending/` (items awaiting processing) and `done/` (items already processed). The queue is initialised by `initQueue` and driven by `runQueue`. | "work queue", "job queue" |
+| **Queue item** | A single unit of work in the analysis queue: one triangulation plus provenance metadata (`parent`, `depth`, `seq`). Serialised as a readable M2 `HashTable` in a zero-padded file (e.g. `0001`). | "work item", "item file" |
+| **Pending file** | A queue item file in `pending/` awaiting processing. Written by `writeQueueItem`. Moved to `done/` (as a done file) by `processQueueItem` after the item is processed. | "input file" (within queue context) |
+| **Done file** (updated) | A queue item file in `done/` that has been processed. Written by `writeDoneItem`. Contains the same fields as the pending file (`parent`, `depth`, `seq`, `triangulation`) plus a `critRegions` key holding the list of critical region `HashTable` objects found during processing (serialised via `toExternalString`). | "output file" (within queue context) |
+| **`item_started` event** (new) | A structured SSE event emitted to stderr by `emitItemStarted` when `processQueueItem` begins processing an item. JSON shape: `{"type":"item_started","item":"<name>","depth":<n>,"parent":"<name>"}`. Forwarded to the browser by the C# SSE pass-through. | — |
+| **`item_done` event** (updated) | A structured SSE event emitted to stderr by `emitItemDone` when `processQueueItem` finishes an item. JSON shape: `{"type":"item_done","item":"<name>","splits":<n>,"critRegions":[...]}`. The `critRegions` array contains one object per critical region found, each with `regionShape` (string), `boundaryVertexCount` (integer), and `innerVertexCount` (integer). Previously the event did not include `critRegions`. Forwarded to the browser by the C# SSE pass-through without modification. | — |
+| **`run_complete` event** | A structured SSE event emitted when `runQueue` empties `pending/` naturally. JSON: `{"type":"run_complete"}`. | — |
+| **`run_paused` event** | A structured SSE event emitted when `runQueue` stops early due to a cap (item cap, vertex cap, timeout, or stop signal). JSON: `{"type":"run_paused"}`. | — |
+
+---
+
 ### M2 Scripts & Files (App-Layer References)
 
 | Term | Definition | Aliases to avoid |
@@ -96,6 +111,8 @@ Canonical terminology for the ext-shifting-app codebase: backend, frontend, API,
 - A **run name** is supplied at job start and used as the key for all output files on the **Docker volume** and as the path parameter in `/analysis/results/{runName}/csv`.
 - **Surface type** determines the starting `input_0` file: `Torus` → `irred tori.m2`, `KleinBottle` → `irred kb.m2`, `ProjectivePlane` → `irred pp.m2`, `Custom` → a user-supplied path.
 - The **git submodule** at `m2/ext-shifting` is the default source of all M2 scripts. A **local mount** in `docker-compose.yml` overrides it for developer workflows. The app does not distinguish between these two cases at runtime.
+- The **analysis queue** is driven by `runQueue`, which calls `processQueueItem` for each item. `processQueueItem` emits an **`item_started` event** at the start and an **`item_done` event** at the end. The C# SSE pass-through forwards these events to the browser without parsing them. The **done file** written per item now includes `critRegions` data co-located with provenance metadata.
+- **`item_done` events** carry `critRegions` as a JSON array of objects whose shape mirrors the M2 `HashTable` fields (`regionShape`, `boundaryVertexCount`, `innerVertexCount`) defined in `m2/ext-shifting/UBIQUITOUS_LANGUAGE.md`.
 
 ---
 

--- a/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
+++ b/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
@@ -53,6 +53,10 @@ public class M2IntegrationTests
 
     [Fact]
     [Trait("Category", "M2Integration")]
+    public Task QueueOps_ProcessItem_CritRegions_Passes() => RunScript("queueOps-processItem-critRegions.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
     public Task QueueOps_RunQueue_ItemCap_Passes() => RunScript("queueOps-runQueue-itemCap.m2");
 
     [Fact]

--- a/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
+++ b/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
@@ -45,6 +45,10 @@ public class M2IntegrationTests
 
     [Fact]
     [Trait("Category", "M2Integration")]
+    public Task AnalyzeIteration_Torus7v_NoCritRegions_Passes() => RunScript("analyzeIteration-torus7v.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
     public Task QueueOps_ProcessItem_Moves_Passes() => RunScript("queueOps-processItem-moves.m2");
 
     [Fact]


### PR DESCRIPTION
## Summary

- Removes the hardcoded trivial disk seed (`makeCritRegion("disk",3,0)`) from `analyzeIteration` — it appeared in every run's output despite being mathematically uninformative
- Bumps `m2/ext-shifting` submodule to pick up the fix, a new `TEST ///` unit test, and `tests/analyzeIteration-torus7v.m2`
- Registers `AnalyzeIteration_Torus7v_NoCritRegions_Passes` in `M2IntegrationTests.cs`

Closes #81

## Test plan

- [x] New `TEST ///` block (empty input → empty critRegions) passes under `check "ExtShifting"`
- [x] `analyzeIteration-torus7v.m2` — `irredTori_0` produces no critical regions
- [x] Full suite passes (`dotnet test` — 109/109)

🤖 Generated with [Claude Code](https://claude.com/claude-code)