### PR TITLE
feat(#88): add splitFrom provenance to queue files

### DIFF
--- a/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
+++ b/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
@@ -61,6 +61,10 @@ public class M2IntegrationTests
 
     [Fact]
     [Trait("Category", "M2Integration")]
+    public Task QueueOps_ProcessItem_SplitFrom_Passes() => RunScript("queueOps-processItem-splitFrom.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
     public Task QueueOps_RunQueue_ItemCap_Passes() => RunScript("queueOps-runQueue-itemCap.m2");
 
     [Fact]


### PR DESCRIPTION
## Summary
- Bumps `m2/ext-shifting` submodule to commit with `splitFrom` provenance (ank1494/ext-shifting#24)
- Registers new `QueueOps_ProcessItem_SplitFrom_Passes` integration test in `M2IntegrationTests.cs`

## Test plan
- [ ] `dotnet test` passes (all 110 tests including `QueueOps_ProcessItem_SplitFrom_Passes`)
- [ ] QA plan #89 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)