### PR TITLE
fix(#26): bump ext-shifting submodule (exempt-split filter timing)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,7 +1,6 @@
 # Backlog
 
-- **Split exemption correctness** `[large] [high]`: The split exemption mechanism in `getCritRegions` has gaps that risk incorrect results — both in when exemptions are applied relative to the critical regions search, and in the logic for which splits to exempt based on triangulation symmetry.
-  - **Exempt-split filter timing in getCritRegions** `[small] [high]`: The exempt-split filter is applied before the critical regions search, meaning exempted splits are excluded from consideration when identifying critical regions. This ordering risk grows as additional exemption cases are introduced.
+- **Split exemption correctness** `[large] [mid]`: The split exemption mechanism in `getCritRegions` has gaps that risk incorrect results — both in when exemptions are applied relative to the critical regions search, and in the logic for which splits to exempt based on triangulation symmetry.
   - **Automorphism-aware split filtering** `[large] [mid]`: The analysis does not account for triangulation symmetry when selecting split candidates. Vertices in the same automorphism orbit are redundant to split at, and vertices with non-trivial symmetries may also be skippable — the split exemption mechanism is a likely vehicle for both filters. For each split that is filtered out, it should be documented which non-filtered split in the same orbit covers it. Sized large because automorphism groups must be determined offline per triangulation and encoded as hard-coded exemptions, spanning potentially many triangulations.
 
 - **M2 code change behavior** `[large] [mid]`: The app references Macaulay2 code that can change externally (e.g. switching branches on ext-shifting). It is unclear how the app should respond to such changes.


### PR DESCRIPTION
Bumps the ext-shifting submodule to pick up ank1494/ext-shifting#27.

No app-layer code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)