### PR TITLE
feat(#104): permutation algebra library

### DIFF
--- a/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
+++ b/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
@@ -69,6 +69,14 @@ public class M2IntegrationTests
 
     [Fact]
     [Trait("Category", "M2Integration")]
+    public Task Automorphisms_Tori_Passes() => RunScript("automorphisms-tori.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
+    public Task Automorphisms_Kb_Passes() => RunScript("automorphisms-kb.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
     public async Task M2LibChecks_PassAllUnitTests()
     {
         if (!Runner.IsAvailable()) return; // skip: M2 not available


### PR DESCRIPTION
## Summary
- Bumps the `ext-shifting` submodule to include `lib/permutations.m2`: `groupClosure`, `isAutomorphism`, `applyPermutationToSplit`, and `isExemptionValid`
- Blocked by / prerequisite for #105

## Test plan
- [ ] `dotnet test` passes (125 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)