### PR TITLE
feat(#105): automorphism data files and verification tests

### DIFF
--- a/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
+++ b/src/ExtShiftingApp.Tests/M2IntegrationTests.cs
@@ -69,6 +69,14 @@ public class M2IntegrationTests
 
     [Fact]
     [Trait("Category", "M2Integration")]
+    public Task Automorphisms_Tori_Passes() => RunScript("automorphisms-tori.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
+    public Task Automorphisms_Kb_Passes() => RunScript("automorphisms-kb.m2");
+
+    [Fact]
+    [Trait("Category", "M2Integration")]
     public async Task M2LibChecks_PassAllUnitTests()
     {
         if (!Runner.IsAvailable()) return; // skip: M2 not available


### PR DESCRIPTION
## Summary
- Adds `toriAutomorphisms.m2` and `kbAutomorphisms.m2`: generator data for all covered triangulations (T0–T4, KB0–4, KB25)
- Adds `tests/automorphisms-tori.m2` and `tests/automorphisms-kb.m2`: verify group order, `isAutomorphism`, `isExemptionValid`, and lex-min orbit invariant
- Registers both test files in `M2IntegrationTests.cs`
- Stacked on #106

## Test plan
- [ ] `dotnet test --filter "FullyQualifiedName~automorphisms"` passes (2 tests)
- [ ] Full `dotnet test` passes (125 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)